### PR TITLE
Add window.CLOSURE_NO_DEPS=true to index.js in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ Create a `src/awesome/main.cljs` file in the `MyAwesomeProject` directory:
 Edit the `index.js` file in the `MyAwesomeProject` directory:
 
 ```javascript
+window.CLOSURE_NO_DEPS = true;
+
 cljsExports = {};
 cljsExports["react"] = require('react');
 cljsExports["react-native"] = require('react-native');


### PR DESCRIPTION
Without this line, with ClojureScript 1.10.764 and figwheel-main 0.2.5 you get an error like this when the app launches. While you can dismiss it, and it doesn't seem to affect anything (the app + REPL + reload still works), it's somewhat annoying. Hence this fix.

![IMG_2FB547AF62BA-1](https://user-images.githubusercontent.com/3014532/82029571-0c85d600-964c-11ea-8a10-a6535b59fc70.jpeg)
